### PR TITLE
Make live-file work behind an https proxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Live-File</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <style type="text/css" rel="stylesheet">
     body{background-color:#222;}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Live-File</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <style type="text/css" rel="stylesheet">
     body{background-color:#222;}


### PR DESCRIPTION
Live file breaks if it sits behind an https proxy because of cross-http call. This fixes it.